### PR TITLE
Remove MixpanelPeople from constructor

### DIFF
--- a/src/@ionic-native/plugins/mixpanel/index.ts
+++ b/src/@ionic-native/plugins/mixpanel/index.ts
@@ -12,7 +12,7 @@ declare var mixpanel: any;
  * ```typescript
  * import { Mixpanel } from '@ionic-native/mixpanel';
  *
- * constructor(private mixpanel: Mixpanel, private mixpanelPeople: MixpanelPeople) { }
+ * constructor(private mixpanel: Mixpanel) { }
  *
  * ...
  *


### PR DESCRIPTION
MixpanelPeople is not needed to make the plugin work, nor does it seem to be part of the native plugin.